### PR TITLE
Støtte for å legge til ytterlige JVM-parametere.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -26,6 +26,7 @@ PROXY_OPTS=$(/proxyopts)
 exec java \
 -XX:+UnlockExperimentalVMOptions \
 -XX:+UseCGroupMemoryLimitForHeap \
+${JAVA_OPTS} \
 ${APPDYNAMICS_OPTS} \
 ${PROXY_OPTS} \
 -server \


### PR DESCRIPTION
Det kan nå legges til ytterligere JVM-parametere ved å definere miljøvariabelen JAVA_OPTS i dockerfilen som bruker dette base-image-et pus-nais-java-app.