### PR TITLE
Bruk nyeste "latest" av baseimage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,4 +18,5 @@ jobs:
           docker build -t ${IMAGE}:java8 java-8
           docker build -t ${IMAGE}:java11 java-11
           docker build -t ${IMAGE}:java13 java-13
+          docker build -t ${IMAGE}:java15 java-15
           docker push ${IMAGE}

--- a/java-11/Dockerfile
+++ b/java-11/Dockerfile
@@ -2,5 +2,5 @@ FROM navikt/java:11-appdynamics
 
 ENV APPD_ENABLED=true
 
-COPY java-debug.sh /init-scripts/08-java-debug.sh
-COPY appd-init.sh /init-scripts/09-appd-init.sh
+COPY --chown=apprunner:root java-debug.sh /init-scripts/08-java-debug.sh
+COPY --chown=apprunner:root appd-init.sh /init-scripts/09-appd-init.sh

--- a/java-13/Dockerfile
+++ b/java-13/Dockerfile
@@ -2,5 +2,5 @@ FROM navikt/java:13-appdynamics
 
 ENV APPD_ENABLED=true
 
-COPY java-debug.sh /init-scripts/08-java-debug.sh
-COPY appd-init.sh /init-scripts/09-appd-init.sh
+COPY --chown=apprunner:root java-debug.sh /init-scripts/08-java-debug.sh
+COPY --chown=apprunner:root appd-init.sh /init-scripts/09-appd-init.sh

--- a/java-15/Dockerfile
+++ b/java-15/Dockerfile
@@ -2,5 +2,5 @@ FROM navikt/java:15-appdynamics
 
 ENV APPD_ENABLED=true
 
-COPY java-debug.sh /init-scripts/08-java-debug.sh
-COPY appd-init.sh /init-scripts/09-appd-init.sh
+COPY --chown=apprunner:root java-debug.sh /init-scripts/08-java-debug.sh
+COPY --chown=apprunner:root appd-init.sh /init-scripts/09-appd-init.sh

--- a/java-8/Dockerfile
+++ b/java-8/Dockerfile
@@ -2,5 +2,5 @@ FROM navikt/java:8-appdynamics
 
 ENV APPD_ENABLED=true
 
-COPY java-debug.sh /init-scripts/08-java-debug.sh
-COPY appd-init.sh /init-scripts/09-appd-init.sh
+COPY --chown=apprunner:root java-debug.sh /init-scripts/08-java-debug.sh
+COPY --chown=apprunner:root appd-init.sh /init-scripts/09-appd-init.sh


### PR DESCRIPTION
Siden nyeste versjon av baseimage kjører som non-root, så må scripts settes til riktig eier for at de skal bli kjørt