### PR TITLE
Opprett directory for securelogs for apprunner

### DIFF
--- a/java-11/Dockerfile
+++ b/java-11/Dockerfile
@@ -4,3 +4,9 @@ ENV APPD_ENABLED=true
 
 COPY --chown=apprunner:root java-debug.sh /init-scripts/08-java-debug.sh
 COPY --chown=apprunner:root appd-init.sh /init-scripts/09-appd-init.sh
+
+USER root
+
+RUN mkdir /secure-logs && chown apprunner:root /secure-logs
+
+USER apprunner

--- a/java-13/Dockerfile
+++ b/java-13/Dockerfile
@@ -4,3 +4,10 @@ ENV APPD_ENABLED=true
 
 COPY --chown=apprunner:root java-debug.sh /init-scripts/08-java-debug.sh
 COPY --chown=apprunner:root appd-init.sh /init-scripts/09-appd-init.sh
+
+USER root
+
+RUN mkdir /secure-logs && chown apprunner:root /secure-logs
+
+USER apprunner
+

--- a/java-15/Dockerfile
+++ b/java-15/Dockerfile
@@ -4,3 +4,9 @@ ENV APPD_ENABLED=true
 
 COPY --chown=apprunner:root java-debug.sh /init-scripts/08-java-debug.sh
 COPY --chown=apprunner:root appd-init.sh /init-scripts/09-appd-init.sh
+
+USER root
+
+RUN mkdir /secure-logs && chown apprunner:root /secure-logs
+
+USER apprunner

--- a/java-8/Dockerfile
+++ b/java-8/Dockerfile
@@ -4,3 +4,9 @@ ENV APPD_ENABLED=true
 
 COPY --chown=apprunner:root java-debug.sh /init-scripts/08-java-debug.sh
 COPY --chown=apprunner:root appd-init.sh /init-scripts/09-appd-init.sh
+
+USER root
+
+RUN mkdir /secure-logs && chown apprunner:root /secure-logs
+
+USER apprunner


### PR DESCRIPTION
Apprunner har ikke tilgang til å opprette filer under "/" runtime, så secure-logs må opprettes med riktig permissions under byggingen av imaget